### PR TITLE
feat: Allow more customisation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,8 +5,11 @@ branding:
   color: 'orange'
 inputs:
   task-definition:
-    description: 'The name of ECS task definition'
-    required: true
+    description: 'The name of the file containing the ECS task definition. One of task-definition or task-definition-arn must be provided.'
+    required: false
+  task-definition-revision-arn:
+    description: 'The ARN of the ECS task defintion revision to run. One of task-definition or task-definition-arn must be provided.'
+    required: false
   cluster:
     description: "The name of the ECS cluster. Will default to the 'default' cluster"
     required: true
@@ -52,6 +55,13 @@ inputs:
     required: false
   task-execution-role-override:
     description: A role ARN for task execution permissions so that it also is not hardcoded within the task definition
+    required: false
+  container-overrides:
+    description: |
+      A string containing JSON to pass to runTask in the containerOverrides section.
+      For example, can be used to override the command run on each container. 
+      See the AWS documentation for full information on the format:
+      https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html
     required: false
 outputs:
   task-definition-arn:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

1. Allow users to pass in TaskDefARN rather than TaskDefFile.
2. Allow users to pass in ContainerOverrides JSON.

Taken together, these 2 changes allow a user to re-use the same TaskDefinitionVersion to run multiple commands using this action. Eg, a flow could be defined where a TaskDefinitionVersion is used to execute a dry-run of a task (such as a database migration), and once this has been checked / approved, the next step could be to re-use the same TaskDefinitionVersion to run the task 'for real'. Creating an extra TaskDefinitionVersion in this case is unnecessary for the 2nd step (it can re-use the TaskDefVersion from the 1st step) - it just needs to be able to override the command executed on the container, which can be achieved via the `containerOverrides` param.