### PR TITLE
fix: output task def family:revision

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -66,6 +66,8 @@ inputs:
 outputs:
   task-definition-arn:
     description: 'The ARN of the registered ECS task definition'
+  task-definition-family-and-revision:
+    description: 'The family & revision of the registered task definition - eg. "my-task-family:1"'
   task-arn:
     description: 'The ARN of the ECS task'
 runs:

--- a/index.js
+++ b/index.js
@@ -164,9 +164,9 @@ async function run() {
      * Useful for later using `aws ecs describe-task-definition` to get the full ARN,
      * since outputting full ARN can be misinterpreted as a secret by Github Actions.
      */
-    const regex = new RegExp('/task-definition/([A-Z0-9-_]+):([0-9]+)/');
-    const matches = 'https://vine.co/v/Mipm1LMKVqJ/embed'.match(regex);
-    core.setOutput('task-definition-family-and-revision', `${matches[1]}:${matches[2]}`)
+    const regex = new RegExp(':task-definition/(.*)$');
+    const matches = taskDefRevisionArn.match(regex);
+    core.setOutput('task-definition-family-and-revision', matches[1])
 
     const clusterName = cluster ? cluster : 'default';
 

--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ async function run() {
 
     // Register the task definition if necessary - or use the passed in ARN
     if (!taskDefinitionFile && !taskDefRevisionArn) {
-      const msg = "Invalid parameters: One of task-definition-file or task-definition-arn must be set";
+      const msg = "Invalid parameters: One of task-definition or task-definition-revision-arn must be set";
       core.setFailed(msg);
       throw new Error(msg);
     }
@@ -157,7 +157,16 @@ async function run() {
     } else {
       core.debug(`Using the passed task definition ARN ${taskDefRevisionArn}`);
     }
+
     core.setOutput('task-definition-arn', taskDefRevisionArn);
+
+    /* Extract task-definition-family & revision ARN, so we can output family:revision
+     * Useful for later using `aws ecs describe-task-definition` to get the full ARN,
+     * since outputting full ARN can be misinterpreted as a secret by Github Actions.
+     */
+    const regex = new RegExp('/task-definition/([A-Z0-9-_]+):([0-9]+)/');
+    const matches = 'https://vine.co/v/Mipm1LMKVqJ/embed'.match(regex);
+    core.setOutput('task-definition-family-and-revision', `${matches[1]}:${matches[2]}`)
 
     const clusterName = cluster ? cluster : 'default';
 

--- a/index.test.js
+++ b/index.test.js
@@ -63,7 +63,7 @@ describe('Deploy to ECS', () => {
         mockEcsRegisterTaskDef.mockImplementation(() => {
             return {
                 promise() {
-                    return Promise.resolve({ taskDefinition: { taskDefinitionArn: 'task:def:arn' } });
+                    return Promise.resolve({ taskDefinition: { taskDefinitionArn: 'task:def:arn:task-definition/task-def-family:1' } });
                 }
             };
         });
@@ -132,10 +132,11 @@ describe('Deploy to ECS', () => {
         await run();
         expect(core.setFailed).toHaveBeenCalledTimes(0);
         expect(mockEcsRegisterTaskDef).toHaveBeenNthCalledWith(1, { family: 'task-def-family'});
-        expect(core.setOutput).toHaveBeenNthCalledWith(1, 'task-definition-arn', 'task:def:arn');
+        expect(core.setOutput).toBeCalledWith('task-definition-arn', 'task:def:arn:task-definition/task-def-family:1');
+        expect(core.setOutput).toBeCalledWith('task-definition-family-and-revision', 'task-def-family:1');
         expect(mockRunTasks).toHaveBeenNthCalledWith(1, {
             cluster: 'cluster-789',
-            taskDefinition: 'task:def:arn',
+            taskDefinition: 'task:def:arn:task-definition/task-def-family:1',
             count: '1',
             startedBy: 'amazon-ecs-run-task-for-github-actions',
             networkConfiguration: {
@@ -166,13 +167,15 @@ describe('Deploy to ECS', () => {
         expect(core.setFailed).toHaveBeenCalledTimes(0);
 
         expect(mockEcsRegisterTaskDef).toHaveBeenNthCalledWith(1, { family: 'task-def-family'});
-        expect(core.setOutput).toHaveBeenNthCalledWith(1, 'task-definition-arn', 'task:def:arn');
+        expect(core.setOutput).toBeCalledWith('task-definition-arn', 'task:def:arn:task-definition/task-def-family:1');
+        expect(core.setOutput).toBeCalledWith('task-definition-family-and-revision', 'task-def-family:1');
         expect(mockEcsDescribeTasks).toHaveBeenNthCalledWith(1, {
             cluster: 'cluster-789',
             tasks:  ['arn:aws:ecs:fake-region:account_id:task/arn']
         });
 
         expect(mockEcsWaiter).toHaveBeenCalledTimes(1);
+        expect(core.setOutput).toBeCalledWith('task-arn', ['arn:aws:ecs:fake-region:account_id:task/arn']);
 
         expect(core.info).toBeCalledWith("All tasks have exited successfully.");
     });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Attempt to get around annoying github actions interpreting ARN as a secret and not letting it be used as a job output
